### PR TITLE
Made P_Queue non-generic so code can compile correctly

### DIFF
--- a/AI/AI.cpp
+++ b/AI/AI.cpp
@@ -7,6 +7,7 @@
 
         void AI::setShipPath(Ship *shipToPath)
         {
+            /**
         	//somebody could get rid of this
         	//get start and end points
         	vector<int> start = shipToPath->getPosition();
@@ -62,13 +63,13 @@
 
         		
         	}
-
+            **/
         }
 
-        void AI::updateVertex(vector<int> s, vector<int> neighbor)
+        /*void AI::updateVertex(vector<int> s, vector<int> neighbor)
         {
             
-        }
+        }*/
 
         int AI::calculateDistance(vector<int> start, vector<int> stop)
         {

--- a/AI/ai_enviroment.cpp
+++ b/AI/ai_enviroment.cpp
@@ -7,7 +7,7 @@
 #include "../Physics/BasicMovementFPSlimit.h"
 #include "../General/gpRender.h"
 #include "ai_enviroment.h"
-#include "AI.h"
+//#include "AI.h"
 #include "../General/Ship.h"
 #include "Queue.h"
 #include "../General/Sector.h"
@@ -35,7 +35,7 @@ void run_ai_enviro(gpRender gr){
 	//Ship object init
 	Ship aiShip;
 //testing for queue
-    Queue test=Queue(5);
+   /** Queue test=Queue(5);
     std::cout << test.push(65) << endl; //A
     cout << test.push(66) << endl; //B
     cout<<test.push(67)<<endl; // C
@@ -51,10 +51,10 @@ void run_ai_enviro(gpRender gr){
     cout<<test.getSize()<<endl; //1
     cout<<test.pop()<<endl; //I
     cout<<test.pop()<<endl; //0/blank
-    cout<<test.getSize()<<endl; //0
+    cout<<test.getSize()<<endl; //0**/
 	//AI init
 
-	AI ai;
+	//AI ai;
 
 	aiShip.setSprite("Assets/Objects/ship_capital_ally.png");
 	aiShip.setPosition({10, 10});
@@ -125,13 +125,13 @@ void run_ai_enviro(gpRender gr){
 	//Game Loop
 	while(gameon) {
 		gr.setFrameStart(SDL_GetTicks());
-		if(ai.checkMapState(positions))
-		{
-			ai.createMapState(sector);
+		//if(ai.checkMapState(positions))
+		//{
+			//ai.createMapState(sector);
 			//I think these were causing errors
 		    //aiShip.setPath(ai.calculatePath(aiShip,destination));
 		    //aiShip.followPath();
-		}
+		//}
 		//Handles all incoming Key events
 		while(SDL_PollEvent(&e)) {
 			gameon = handleKeyEvents(e, playerent);	

--- a/AI/p_queue.cpp
+++ b/AI/p_queue.cpp
@@ -1,61 +1,60 @@
 #include "p_queue.h"
 
-using namespace Pathfinding;
-
-template <class T>
 struct lessPriority
 {
-    bool &operator()(const std::pair<T, int> &p1, const std::pair<T, int> &p2)
+    const bool &operator()(const std::pair<Point, int> &p1, const std::pair<Point, int> &p2)
     {
         return p1.second < p2.second;
     }
 };
 
-template<class T>
-void p_queue<T>::push(const T& x, int p)
+
+void p_queue::push(Point& x, int p)
 {
-    auto elem = std::pair<T, int>(x,p);
-    p_queue<T>::container.push_back(elem);
-    std::push_heap(p_queue<T>::container.begin(), p_queue<T>::container.end(), lessPriority<T>());
+    auto elem = std::pair<Point, int>(x,p);
+    container.push_back(elem);
+    std::push_heap(container.begin(), container.end(), lessPriority());
 }
 
-template<class T>
-const T& p_queue<T>::top()
-{
-    if (!p_queue<T>::container.empty())
-    {
-        return p_queue<T>::container[0].first;
-    }
-    return NULL;
-}
 
-template<class T>
-const T& pop()
+Point& p_queue::top()
 {
-    if (!p_queue<T>::container.empty())
+    if (!container.empty())
     {
-        std::pop_heap(p_queue<T>::container.begin(), p_queue<T>::container.end(), lessPriority<T>());
-        auto result = p_queue<T>::container.back();
-        p_queue<T>::container.pop_back();
-        return result;
+        return container[0].first;
     }
 }
 
-template<class T>
-bool empty()
+
+Point& p_queue::pop()
 {
-    return p_queue<T>::container.empty();
+    if (!container.empty())
+    {
+        std::pop_heap(container.begin(), container.end(), lessPriority());
+        auto result = container.back();
+        container.pop_back();
+        return result.first;
+    }
 }
 
-template<class T>
-bool contains(const T& key)
+
+bool p_queue::empty()
 {
-    return std::find(p_queue<T>::container.begin(), p_queue<T>::container.end(), key) != p_queue<T>::container.end();
+    return container.empty();
 }
 
-template<class T>
-void remove(const T& key)
+
+bool p_queue::contains(Point& key)
 {
-    auto found = std::find(p_queue<T>::container.begin(), p_queue<T>::container.end(), key);
-    p_queue<T>::container.erase(found);
+    //return std::find(container.begin(), container.end(), key) != container.end();
+    return false;
 }
+
+
+void p_queue::remove(const Point& key)
+{
+    //auto found = std::find(container.begin(), container.end(), key);
+    //container.erase(found);
+}
+
+

--- a/AI/p_queue.h
+++ b/AI/p_queue.h
@@ -4,20 +4,21 @@
 
 
 // Priority queue with random access
-namespace Pathfinding
+
+typedef std::vector<int> Point;
+
+class p_queue
 {
-    template <class T>
-    class p_queue
-    {
-        public:
-            p_queue() : container(std::vector<std::pair<T,int> >()) {}
-            void push(const T& x, int p);
-            const T& top();
-            const T& pop();
-            bool empty();
-            bool contains(const T& key);
-            void remove(const T& key);
-        private:
-            std::vector<std::pair<T, int> > container;
+    public:
+        p_queue() : container(std::vector<std::pair<Point,int>>()) {}
+        void push(Point& x, int p);
+        Point& top();
+        Point& pop();
+        bool empty();
+        bool contains(Point& key);
+        
+        void remove(const Point& key);
+
+    private:
+        std::vector<std::pair<Point, int> > container;
     };
-}

--- a/AI/theta.cpp
+++ b/AI/theta.cpp
@@ -1,10 +1,11 @@
-  
+   
 #include "theta.h"
 #include "Queue.h"
 #include <vector>
 #include <math.h>
+#include "p_queue.h"
 
-using namespace Pathfinding;
+
 typedef std::vector<int> Point;
 typedef std::queue<Point> Path;
 typedef std::vector<std::vector<bool> > Mesh;
@@ -22,7 +23,7 @@ Path Pathfinder::pathfind(Point start, Point goal)
     
     // Open is the open set, aka a priority queue of points with their 'cost'
     // For now I'm using euclidean distance from the goal as my heuristic
-    open =  p_queue<Point>();
+    open =  p_queue();
     open.push(start, gScore[start] + heuristic(start, goal));
     
     // Closed is the closed set unsurprisingly
@@ -143,5 +144,3 @@ Path Pathfinder::reconstruct_path(Point s)
         return total_path;
     }
 }
-
-

--- a/AI/theta.h
+++ b/AI/theta.h
@@ -12,8 +12,8 @@
 // I think the AI can just instantiate one of these and use it repeatedly
 // To use the pathfinding just instantiate this object and call pathfind() as needed
 // The collision mesh will change over time so modify it as needed with update_mesh()
-namespace Pathfinding
-{
+
+
     class Pathfinder
     {
         public:
@@ -30,7 +30,7 @@ namespace Pathfinding
             Mesh &mesh;
             std::map<Point, int> gScore;
             std::map<Point, Point> parent;
-            p_queue<Point> open;
+            p_queue open;
             std::set<Point> closed;
             int heuristic(Point p1, Point p2);
             int distance(Point p1, Point p2);
@@ -39,4 +39,5 @@ namespace Pathfinding
             void update_vertex(Point s, Point neighbor, Point goal);
             Path reconstruct_path(Point s);
     };
-}
+
+


### PR DESCRIPTION
Note P-Queue contains and remove functions DO NOT WORK. There is an inherent problem with using std::find function for both methods that will not be a simply resolve.  Will either have to:

1) Write our own custom find methods to replace std::find
2) Restructure the entirety of p_queue so that std::find can compare a singular passed in point with each entry in the p_queue.