### PR TITLE
HP changes, rendering changes, and some small fixes

### DIFF
--- a/General/HpBar.cpp
+++ b/General/HpBar.cpp
@@ -2,8 +2,7 @@
 #include <SDL.h>
 
 	HpBar::HpBar() {};
-	HpBar::HpBar(SDL_Rect dBox, SDL_Texture* aTex, float percentage): Sprite(dBox, aTex), percentage{percentage}{};
-	renderOrder = 3;
+	HpBar::HpBar(SDL_Rect dBox, SDL_Texture* aTex, float percentage): Sprite(dBox, aTex), percentage{percentage}{renderOrder = 3;};
 	HpBar::~HpBar()
 	{
 		SDL_DestroyTexture(assetTex);

--- a/General/HpBar.cpp
+++ b/General/HpBar.cpp
@@ -3,6 +3,7 @@
 
 	HpBar::HpBar() {};
 	HpBar::HpBar(SDL_Rect dBox, SDL_Texture* aTex, float percentage): Sprite(dBox, aTex), percentage{percentage}{};
+	renderOrder = 3;
 	HpBar::~HpBar()
 	{
 		SDL_DestroyTexture(assetTex);

--- a/General/Ship.cpp
+++ b/General/Ship.cpp
@@ -4,11 +4,11 @@
 #include <iostream>
     Ship::Ship(): Sprite() {};
 
-    Ship::Ship(SDL_Rect dBox, SDL_Texture* aTex): Sprite(dBox, aTex) {};
+    Ship::Ship(SDL_Rect dBox, SDL_Texture* aTex): Sprite(dBox, aTex) {renderOrder = 1;};
 
-    Ship::Ship(SDL_Rect dBox, SDL_Texture* aTex, int anim): Sprite(dBox, aTex, anim) {};
+    Ship::Ship(SDL_Rect dBox, SDL_Texture* aTex, int anim): Sprite(dBox, aTex, anim) {renderOrder = 1;};
 
-    Ship::Ship(SDL_Rect dBox, SDL_Texture* aTex, int anim, int mass): Sprite(dBox, aTex, anim), mass{mass} {};
+    Ship::Ship(SDL_Rect dBox, SDL_Texture* aTex, int anim, int mass): Sprite(dBox, aTex, anim), mass{mass} {renderOrder = 1;};
 
     Ship::~Ship()
     {
@@ -90,14 +90,24 @@
         return maxVelocity;
     }
 
-    int Ship::getHp()
+    int Ship::getCurrHp()
     {
-	return hp;    
+       return currHp;    
     }
 
-    void Ship::setHp(int newHp)
+    void Ship::setCurrHp(int newCurrHp)
     {
-	hp = newHp;    
+       currHp = newCurrHp;    
+    }
+
+    int Ship::getMaxHp()
+    {
+	   return maxHp;    
+    }
+
+    void Ship::setMaxHp(int newMaxHp)
+    {
+	   maxHp = newMaxHp;    
     }
 
     //ai follows path assigned to it by ai class

--- a/General/Ship.h
+++ b/General/Ship.h
@@ -24,7 +24,8 @@ class Ship : public Sprite
 
         float speedX;
         float speedY;
-        int hp;
+        int currHp;
+        int maxHp;
 
         //ai
         std::queue<pair<int,int>>* path;
@@ -60,8 +61,10 @@ class Ship : public Sprite
         int getMaxVelocity();
         void setDestination(pair<int,int> newDestination);
         int getMass();
-        void setHp(int newHp);
-        int getHp();
+        void setCurrHp(int newCurrHp);
+        int getCurrHp();
+        void setMaxHp(int newMaxHp);
+        int getMaxHp();
 };
 
 class Hero:Ship{};

--- a/General/Sprite.cpp
+++ b/General/Sprite.cpp
@@ -78,6 +78,12 @@
 	int Sprite::getF(){
 		return animFrame;
 	}
+	void Sprite::setRenderOrder(int new_order){
+		renderOrder = new_order;
+	}
+	int Sprite::getRenderOrder(){
+		return renderOrder;
+	}
 	
 
 	//--------------------------Functions Related to Drawing a Rectangle-----------------------------------------

--- a/General/Sprite.h
+++ b/General/Sprite.h
@@ -44,7 +44,8 @@ class Sprite{
 		void setF(int anim);
 		int getF();
 
-	
+		int getRenderOrder();
+		void setRenderOrder(int new_order);
 
 		
 		//Methods that deal with Rectangle drawn entities
@@ -58,11 +59,11 @@ class Sprite{
 	
 
 	protected:
-		float x,y;
 		SDL_Rect drawBox;
 		NSDL_Circ drawCirc;
 		SDL_Texture* assetTex;
 		int animFrame;
+		float x,y;
 		int renderOrder;
 
 		//Velocity variables

--- a/General/Sprite.h
+++ b/General/Sprite.h
@@ -63,6 +63,7 @@ class Sprite{
 		NSDL_Circ drawCirc;
 		SDL_Texture* assetTex;
 		int animFrame;
+		int renderOrder;
 
 		//Velocity variables
 		//Probably should be moved to some physic related object

--- a/General/Star.cpp
+++ b/General/Star.cpp
@@ -1,73 +1,73 @@
 #include "Star.h"
 Star::Star(): Sprite() {};
-Star::Star(SDL_Rect dBox, SDL_Texture* aTex): Sprite(dBox, aTex) {};
+Star::Star(SDL_Rect dBox, SDL_Texture* aTex): Sprite(dBox, aTex){renderOrder = 2;};
 
-Star::Star(SDL_Rect dBox, SDL_Texture* aTex, int mass): Sprite(dBox, aTex), mass{mass} {};
+Star::Star(SDL_Rect dBox, SDL_Texture* aTex, int mass): Sprite(dBox, aTex), mass{mass}{renderOrder = 2;};
 
-int Star::getRadius()
-{
-	return radius;
-}
+	int Star::getRadius()
+	{
+		return radius;
+	}
 
-int Star::getGravity()
-{
-	return gravity;
-}
+	int Star::getGravity()
+	{
+		return gravity;
+	}
 
-string Star::getType()
-{
-	return type;
-}
+	string Star::getType()
+	{
+		return type;
+	}
 
-vector<int> Star::getPosition()
-{
-	return position;
-}
+	vector<int> Star::getPosition()
+	{
+		return position;
+	}
 
-string Star::getSprite()
-{
-	return sprite;
-}
+	string Star::getSprite()
+	{
+		return sprite;
+	}
 
-void Star::setRadius(int r)
-{
-	radius = r;
-}
+	void Star::setRadius(int r)
+	{
+		radius = r;
+	}
 
-void Star::setGravity(int g)
-{
-	gravity = g;
-}
+	void Star::setGravity(int g)
+	{
+		gravity = g;
+	}
 
-void Star::setType(string t)
-{
-	type = t;
-}
+	void Star::setType(string t)
+	{
+		type = t;
+	}
 
-void Star::setPosition(vector<int> newPos)
-{
-	position = newPos;
-}
+	void Star::setPosition(vector<int> newPos)
+	{
+		position = newPos;
+	}
 
-void Star::setSprite(string s)
-{
-	sprite = s;
-}
-	
-int Star::getMass(){
-	return mass;	
-}
+	void Star::setSprite(string s)
+	{
+		sprite = s;
+	}
+		
+	int Star::getMass(){
+		return mass;	
+	}
 
-void Star::setMass(int newMass){
-	mass = newMass;	
-}
+	void Star::setMass(int newMass){
+		mass = newMass;	
+	}
 
-vector<int> Star::getSize()
-{
-	return size;
-}
+	vector<int> Star::getSize()
+	{
+		return size;
+	}
 
-void Star::setSize(vector<int> newSize)
-{
-	size = newSize;
-}
+	void Star::setSize(vector<int> newSize)
+	{
+		size = newSize;
+	}

--- a/General/demo.cpp
+++ b/General/demo.cpp
@@ -63,6 +63,9 @@ void run_demo(gpRender gr){
 	SDL_Texture* tex = gr.loadImage("Assets/Objects/ship_player.png");
 	SDL_Rect db = {SCREEN_WIDTH/2 - PLAYER_WIDTH/2,SCREEN_HEIGHT/2 - PLAYER_HEIGHT/2,PLAYER_WIDTH,PLAYER_HEIGHT};
 	Ship playerent(db, tex, 0);
+	playerent.setRenderOrder(0);
+	playerent.setCurrHp(100);
+	playerent.setMaxHp(100);
 	osSprite.push_back(&playerent);
 	
 	
@@ -140,7 +143,7 @@ void run_demo(gpRender gr){
 
 	SDL_Texture* texhp = gr.loadImage("Assets/Objects/hp_bar.png");
 	SDL_Rect hp = {10,10,300,20};
-	HpBar hpent(hp, texhp, playerent.getHp());
+	HpBar hpent(hp, texhp, playerent.getCurrHp()/playerent.getMaxHp());
 	osSprite2.push_back(&hpent);
 	/*
 	//Ship Cruiser initilization

--- a/General/gpRender.cpp
+++ b/General/gpRender.cpp
@@ -113,7 +113,7 @@ void gpRender::renderOnScreenEntity(std::vector<Sprite*> osEntity, std::vector<i
 
 		//To check if entity is player, player must be the first entity added
 		//Also checks if camera should be fixed
-		if ((entity == osEntity.at(0)) && !fixed){
+		if ((entity->getRenderOrder() == 0 || entity == osEntity.at(0)) && !fixed){
 			SDL_Point center;
 			center.x = entity->getW()/2;
 			center.y = entity->getH()/2;
@@ -121,27 +121,10 @@ void gpRender::renderOnScreenEntity(std::vector<Sprite*> osEntity, std::vector<i
 			SDL_Rect animBox = {entity->getF() * entity->getW(), 0, entity->getW(), entity->getH()};
 			SDL_RenderCopyEx(gRenderer, entity->getTexture(), &animBox, &camcenter, entity->getAngle(), &center, SDL_FLIP_NONE);
 		}
-		// checks if it's the hp bar
-		else if (entity == osEntity.at(osEntity.size()-1)){
-			SDL_Point center;
-			int hpX = osEntity.at(0)->getX() - SCREEN_WIDTH*5;
-			int hpY = osEntity.at(0)->getY() - SCREEN_HEIGHT*5;
-			if(hpX < 10)
-				hpX = 10;
-			if(hpY < 10)
-				hpY = 10;
-			entity->setX(hpX);
-			entity->setY(hpY);
-			SDL_Rect campos = {entity->getX(), entity->getY(), entity->getW(), entity->getH()};
-			center.x = entity->getW()/2;
-			center.y = entity->getH()/2;
-			
-			SDL_RenderCopyEx(gRenderer, entity->getTexture(), nullptr, &campos, entity->getAngle(), &center, SDL_FLIP_NONE);
-		}
-
-		//check if entity within range of camera
+		
+		//check if entity within range of camera but ignores UI
 		else if ((camera.x - entity->getW() < entity->getX()) && (entity->getX() < camera.x + SCREEN_WIDTH + entity->getW()) && 
-			(camera.y - entity->getH() < entity->getY()) && (entity->getY() < camera.y + SCREEN_HEIGHT + entity->getH())){
+			(camera.y - entity->getH() < entity->getY()) && (entity->getY() < camera.y + SCREEN_HEIGHT + entity->getH()) && entity->getRenderOrder() != 3){
 			
 			SDL_Rect campos = {entity->getX() - camera.x, entity->getY() - camera.y, entity->getW(), entity->getH()};
 
@@ -161,6 +144,18 @@ void gpRender::renderOnScreenEntity(std::vector<Sprite*> osEntity, std::vector<i
 				entity->getDrawCirc()->RenderFillCirc(gRenderer);
 			}
 		}
+
+		// checks if it's UI
+		if (entity->getRenderOrder() == 3){
+			SDL_Point center;
+			
+			SDL_Rect campos = {entity->getX(), entity->getY(), entity->getW(), entity->getH()};
+			center.x = entity->getW()/2;
+			center.y = entity->getH()/2;
+			
+			SDL_RenderCopyEx(gRenderer, entity->getTexture(), nullptr, &campos, entity->getAngle(), &center, SDL_FLIP_NONE);
+		}
+
 	}
 	
 	

--- a/General/planet.cpp
+++ b/General/planet.cpp
@@ -7,9 +7,9 @@ using namespace std;
 
 
 Planet::Planet(): Sprite() {};
-Planet::Planet(SDL_Rect dBox, SDL_Texture* aTex): Sprite(dBox, aTex) {};
-Planet::Planet(SDL_Rect dBox, SDL_Texture* aTex, int mass): Sprite(dBox, aTex), mass{mass} {};
-Planet::Planet(SDL_Rect dBox, SDL_Texture* aTex, int mass, Star sun): Sprite(dBox, aTex), mass{mass} {initVelocity(sun);};
+Planet::Planet(SDL_Rect dBox, SDL_Texture* aTex): Sprite(dBox, aTex) {renderOrder = 2;};
+Planet::Planet(SDL_Rect dBox, SDL_Texture* aTex, int mass): Sprite(dBox, aTex), mass{mass} {renderOrder = 2;};
+Planet::Planet(SDL_Rect dBox, SDL_Texture* aTex, int mass, Star sun): Sprite(dBox, aTex), mass{mass} {initVelocity(sun); renderOrder = 2;};
 void Planet::initVelocity(Star& star)
 {
 	sun = star;

--- a/Physics/BasicGravity.cpp
+++ b/Physics/BasicGravity.cpp
@@ -43,9 +43,9 @@ std::vector<float> calculateGravityPull(Sprite &playerent, Sprite &bodyent){
 	pointAngle = atan(pointSlope);
 	if(playerX > bodyX)
 	{
-		pointAngle += 3.1415926;
+		pointAngle += PI;
 	}
-	std::cout << "angle: " << pointAngle * 180/ 3.14<< std::endl;
+	std::cout << "angle: " << pointAngle * 180/ PI<< std::endl;
 	float grav = 100000/((bodyX-playerX)*(bodyX-playerX)*1.0 + (bodyY-playerY)*(bodyY-playerY)*1.0);
 	std::cout << "grav: " << grav << std::endl;
 	float gravX = grav*cos(pointAngle);

--- a/Physics/phy_enviroment.cpp
+++ b/Physics/phy_enviroment.cpp
@@ -63,7 +63,9 @@ void run_phy_enviro(gpRender gr){
 	SDL_Texture* tex = gr.loadImage("Assets/Objects/ship_player.png");
 	SDL_Rect db = {SCREEN_WIDTH/2 - PLAYER_WIDTH/2,SCREEN_HEIGHT/2 - PLAYER_HEIGHT/2,PLAYER_WIDTH,PLAYER_HEIGHT};
 	Ship playerent(db, tex, 0);
-	playerent.setHp(100);
+	playerent.setCurrHp(100);
+	playerent.setMaxHp(100);
+	playerent.setRenderOrder(0);
 	osSprite.push_back(&playerent);
 	osSprite2.push_back(&playerent);
 
@@ -91,7 +93,7 @@ void run_phy_enviro(gpRender gr){
 	
 	SDL_Texture* texhp = gr.loadImage("Assets/Objects/hp_bar.png");
 	SDL_Rect hp = {10,10,300,20};
-	HpBar hpent(hp, texhp, playerent.getHp());
+	HpBar hpent(hp, texhp, playerent.getCurrHp()/playerent.getMaxHp());
 	osSprite2.push_back(&hpent);
 	
 	srand(time(0));


### PR DESCRIPTION
HP:
HP positioning fixed
Ship hp changed from just hp to currHp and maxHp

Rendering:
RenderOrder added for sprite and default order set for all sprite subclasses + playerent manually set to 0 (since ships default is 1)
gpRender changed to implement renderOrder

Small fixes:
Changed all PIs in BasicGravity to the defined PI instead of every mention of PI having different lengths
New hp (curr and max) implemented in demo and phy environment 